### PR TITLE
[Properties]小項目タイトル及びコード中のコメントの修正

### DIFF
--- a/language-guide/methods.md
+++ b/language-guide/methods.md
@@ -1,6 +1,6 @@
 # メソッド \(Methods\)
 
-最終更新日: 2021/6/28  
+最終更新日: 2022/7/15  
 原文: https://docs.swift.org/swift-book/LanguageGuide/Methods.html
 
 メソッドは、特定の型に紐づいた関数です。クラス、構造体、および列挙型は全て、インスタンスメソッドを定義できます。インスタンスメソッドは、特定の型のインスタンスを操作するための特定のタスクと機能をカプセル化します。クラス、構造体、および列挙型は、型自体に関連付けられている型メソッドを定義することもできます。型メソッドは、Objective-C のクラスメソッドに似ています。
@@ -111,7 +111,7 @@ print("The point is now at (\(somePoint.x), \(somePoint.y))")
 
 上記の `Point` 構造体は、自身に変更を加える `moveBy(x:y:)` メソッドを定義します。これは、`Point` インスタンスを一定量移動します。新しいポイントを返す代わりに、呼び出されたポイントを実際に変更します。プロパティを変更できるようにするために、`mutating` キーワードがその定義に追加されてます。
 
-[Stored Properties of Constant Structure Instances\(定数の格納インスタンスのプロパティ\)](../language-guide/properties.md#stored-properties-of-constant-structure-instances)で説明されているように、構造体の定数内の変数プロパティを変更できないため、構造体の定数で変更メソッドを呼び出すことはできないことに注意してください。
+[Stored Properties of Constant Structure Instances\(定数に割り当てられた構造体のインスタンスの格納プロパティ\)](../language-guide/properties.md#stored-properties-of-constant-structure-instances)で説明されているように、構造体の定数内の変数プロパティを変更できないため、構造体の定数で変更メソッドを呼び出すことはできないことに注意してください。
 
 ```swift
 let fixedPoint = Point(x: 3.0, y: 3.0)

--- a/language-guide/properties.md
+++ b/language-guide/properties.md
@@ -1,6 +1,6 @@
 # プロパティ\(Properties\)
 
-最終更新日: 2021/6/27  
+最終更新日: 2022/7/15  
 原文: https://docs.swift.org/swift-book/LanguageGuide/Properties.html
 
 プロパティは、値を特定のクラス、構造体、または列挙型に関連付けます。_格納プロパティ_は定数と変数の値をインスタンスの一部として保存しますが、_計算プロパティ_は値を\(保存するのではなく\)計算します。計算プロパティは、クラス、構造体、および列挙型で使用できます。格納プロパティは、クラスと構造体のみで使用できます。
@@ -32,13 +32,13 @@ rangeOfThreeItems.firstValue = 6
 
 `FixedLengthRange` のインスタンスには、`firstValue` と呼ばれる変数格納プロパティと `length` という定数格納プロパティがあります。上記の例では、定数のため、長さは新しい範囲が作成されたときに初期化され、それ以降は変更できません。
 
-### <a id="stored-properties-of-constant-structure-instances">定数の格納インスタンスのプロパティ\(Stored Properties of Constant Structure Instances\)</a>
+### <a id="stored-properties-of-constant-structure-instances">定数に割り当てられた構造体のインスタンスの格納プロパティ\(Stored Properties of Constant Structure Instances\)</a>
 
 構造体のインスタンスを作成し、そのインスタンスを定数に割り当てる場合、インスタンスのプロパティは、変数で宣言されていても変更できません。
 
 ```swift
 let rangeOfFourItems = FixedLengthRange(firstValue: 0, length: 4)
-// 0, 1, 2 の整数の範囲を表しています
+// 0, 1, 2, 3 の整数の範囲を表しています
 rangeOfFourItems.firstValue = 6
 // firstValue は変数ですがエラーになります
 ```


### PR DESCRIPTION
### 小項目タイトルの変更

原文では `Stored Properties of Constant Structure Instances` のところ、`定数の格納インスタンスのプロパティ` と翻訳されていました。
`定数の格納インスタンス`は`定数に格納されたインスタンス` という意味で通りそうですが、それでも`Property`にかかる`Stored`が抜け落ちているため、翻訳として適切でないと思います。

methods.mdからこの項目へのリンクがあったので、併せて修正しています。

### コード中のコメント修正

原文では`// this range represents integer values 0, 1, 2, and 3`です。
3が抜けてコードと矛盾していました。