### PR TITLE
Revert "[CONTRIBUTION]スペースの修正" 

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -41,7 +41,9 @@ npm install
 
 > Swift has struct and class.
 
+<!-- textlint-disable -->
 ❌ Swiftには、structとclassがあります。
+<!-- textlint-enable -->`
 
 ⭕️ Swift には、struct と class があります。
 

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -41,7 +41,7 @@ npm install
 
 > Swift has struct and class.
 
-❌ Swift には、struct と class があります。
+❌ Swiftには、structとclassがあります。
 
 ⭕️ Swift には、struct と class があります。
 


### PR DESCRIPTION
#297 で指摘しましたが、このPRでは正誤対応の誤側を修正してしまっています。
該当箇所はtextlintで勝手に修正されてしまうようだったので、`textlint-disable`で無視するようにしました。