### PR TITLE
README を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## 開発について
 
-[開発ガイド](https://github.com/stzn/the-swift-programming-language-jp/tree/fb429c05ba8213016ca97e93f9454d86ed274ab7/CONTRIBUTION.md)を参照ください。
+[開発ガイド](https://github.com/stzn/the-swift-programming-language-jp/blob/master/CONTRIBUTION.md)を参照ください。
 
 以下の表は用語に関する英和対応表です。これを参考にしながら、できるだけ日本語の列と合うよう表記揺れを抑えます。一般的に邦訳があるもの、Apple がドキュメント内で邦訳で言及したものについてはそれを採用し、適した訳が見つからない場合は英語のまま表記します。随時更新。
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@
 なお、英語のまま表記の大文字、小文字は、原文の記載に従います。
 
 通常の英語と同様に文の開始は大文字、その他は小文字  
-例: 開始 -> Computed property、その他 -> computed property
+例: 開始 -&gt; Computed property、その他 -&gt; computed property
 
 慣例的に大文字、小文字が決まっているもの  
-例: URL、UI、Swift、SwiftUI、HTML、CSSなど
+例: URL、UI、Swift、SwiftUI、HTML、CSS など
 
 |英語|日本語|
 |--------|--------|


### PR DESCRIPTION
- [README] 記号の表現方法を変更
- [README] リンクを修正

開発ガイド (CONTRIBUTION) のリンクが
別のブランチのものを参照しているのですが、
もしかしたら何かの手違いなのではと思います。

確認、お願いします 🙇
